### PR TITLE
[1.20.1] Animation data overloads while loading the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug that allowed the player to replace the current skill slot even during cooldown.
 - Fixed the mining crosshair not to show in vanilla mode
+- Fixed the massive memory consume on loading the game caused by animation loads
 
 ### For Devs
 

--- a/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationClip.java
@@ -15,8 +15,10 @@ public class AnimationClip {
 	
 	protected Map<String, TransformSheet> jointTransforms = new HashMap<> ();
 	protected float clipTime;
-	protected float bakedTimes[];
+	protected float[] bakedTimes;
 	
+	/// To modify existing keyframes in runtime and keep the baked state, call [#setBaked] again
+    /// after finishing clip modification. (Frequent calls of this method will cause a performance issue)
 	public void addJointTransform(String jointName, TransformSheet sheet) {
 		this.jointTransforms.put(jointName, sheet);
 		this.bakedTimes = null;
@@ -26,6 +28,7 @@ public class AnimationClip {
 		return this.jointTransforms.containsKey(jointName);
 	}
 	
+	/// Bakes all keyframes to optimize calculating current pose,
 	public void bakeKeyframes() {
 		Set<Float> timestamps = new HashSet<> ();
 		
@@ -52,9 +55,7 @@ public class AnimationClip {
 		this.bakedTimes = bakedTimestamps;
 	}
 	
-	/**
-	 * Supposes the keyframes are aligned (when creating link animations)
-	 */
+	/// Bake keyframes supposing all keyframes are aligned (mainly used when creating link animations)
 	public void setBaked() {
 		TransformSheet transformSheet = this.jointTransforms.get("Root");
 		
@@ -113,11 +114,7 @@ public class AnimationClip {
 		return pose;
 	}
 	
-	/**
-	 * Warn: do not add or modify the existing entries by native map methods since it breaks baked state
-	 * 
-	 * @return
-	 */
+	/// @return returns protected keyframes of each joint to keep the baked state of keyframes.
 	public Map<String, TransformSheet> getJointTransforms() {
 		return Collections.unmodifiableMap(this.jointTransforms);
 	}

--- a/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
+++ b/src/main/java/yesman/epicfight/api/animation/AnimationManager.java
@@ -1,9 +1,14 @@
 package yesman.epicfight.api.animation;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -18,17 +23,22 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.GsonHelper;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -53,10 +63,12 @@ import yesman.epicfight.network.client.CPCheckAnimationRegistryMatches;
 import yesman.epicfight.network.server.SPDatapackSync;
 
 @SuppressWarnings("unchecked")
-public class AnimationManager extends SimpleJsonResourceReloadListener {
+public class AnimationManager extends SimplePreparableReloadListener<List<ResourceLocation>> {
 	private static final AnimationManager INSTANCE = new AnimationManager();
 	private static ResourceManager serverResourceManager = null;
-	
+	private static final Gson GSON = new GsonBuilder().create();
+    private static final String DIRECTORY = "animmodels/animations";
+    
 	public static AnimationManager getInstance() {
 		return INSTANCE;
 	}
@@ -66,11 +78,7 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 	private final Map<AnimationAccessor<? extends StaticAnimation>, StaticAnimation> animations = Maps.newHashMap();
 	private final Map<AnimationAccessor<? extends StaticAnimation>, String> resourcepackAnimationCommands = Maps.newHashMap();
 	
-	public AnimationManager() {
-		super(new GsonBuilder().create(), "animmodels/animations");
-	}
-	
-	public static boolean checkNonNull(AssetAccessor<? extends StaticAnimation> animation) {
+	public static boolean checkNull(AssetAccessor<? extends StaticAnimation> animation) {
 		if (animation == null || animation.isEmpty()) {
 			if (animation != null) {
 				EpicFightMod.stacktraceIfDevSide("Empty animation accessor: " + animation.registryName(), NoSuchElementException::new);
@@ -78,10 +86,10 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 				EpicFightMod.stacktraceIfDevSide("Null animation accessor", NoSuchElementException::new);
 			}
 			
-			return false;
+			return true;
 		}
 		
-		return true;
+		return false;
 	}
 	
 	public static <T extends StaticAnimation> AnimationAccessor<T> byKey(String registryName) {
@@ -108,22 +116,18 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 	}
 	
 	public AnimationClip loadAnimationClip(StaticAnimation animation, BiFunction<JsonAssetLoader, StaticAnimation, AnimationClip> clipLoader) {
-		try
-		{
+		try {
 			if (getAnimationResourceManager() == null) {
 				return null;
 			}
-
+			
 			JsonAssetLoader modelLoader = new JsonAssetLoader(getAnimationResourceManager(), animation.getLocation());
 			AnimationClip loadedClip = clipLoader.apply(modelLoader, animation);
-
+			
 			return loadedClip;
-		}
-		catch (AssetLoadingException e)
-		{
+		} catch (AssetLoadingException e) {
 			throw new AssetLoadingException("Failed to load animation clip from: " + animation, e);
 		}
-
 	}
 	
 	public static void readAnimationProperties(StaticAnimation animation) {
@@ -140,84 +144,107 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 	}
 	
 	@Override
-	protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profilerIn) {
+	protected List<ResourceLocation> prepare(ResourceManager resourceManager, ProfilerFiller profilerIn) {
 		if (!EpicFightSharedConstants.isPhysicalClient() && serverResourceManager == null) {
 			serverResourceManager = resourceManager;
 		}
 		
 		this.animations.clear();
-		this.animationById.entrySet().removeIf((entry) -> !entry.getValue().inRegistry());
-		this.animationByName.entrySet().removeIf((entry) -> !entry.getValue().inRegistry());
+		this.animationById.entrySet().removeIf(entry -> !entry.getValue().inRegistry());
+		this.animationByName.entrySet().removeIf(entry -> !entry.getValue().inRegistry());
 		this.resourcepackAnimationCommands.clear();
 		
-		return super.prepare(resourceManager, profilerIn);
+        List<ResourceLocation> directories = new ArrayList<> ();
+        scanDirectoryNames(resourceManager, directories);
+        
+		return directories;
 	}
 	
-	@Override
-	protected void apply(Map<ResourceLocation, JsonElement> objectIn, ResourceManager resourceManager, ProfilerFiller profilerIn) {
+    private static void scanDirectoryNames(ResourceManager resourceManager, List<ResourceLocation> output) {
+        FileToIdConverter filetoidconverter = FileToIdConverter.json(DIRECTORY);
+        filetoidconverter.listMatchingResources(resourceManager).keySet().stream().map(AnimationManager::pathToId).forEach(output::add);
+    }
+	
+    @Override
+	protected void apply(List<ResourceLocation> objects, ResourceManager resourceManager, ProfilerFiller profilerIn) {
 		Armatures.reload(resourceManager);
 		
-		Set<ResourceLocation> registeredAnimation = this.animationById.values().stream().reduce(Sets.newHashSet(), (set, accessor) -> {
-			set.add(accessor.registryName());
-			
-			for (AssetAccessor<? extends StaticAnimation> subAnimAccessor : accessor.get().getSubAnimations()) {
-				set.add(subAnimAccessor.registryName());
-			}
-			
-			return set;
-		}, (set1, set2) -> {
-			set1.addAll(set2);
-			return set1;
-		});
+		Set<ResourceLocation> registeredAnimation =
+            this.animationById.values().stream()
+                .reduce(
+                    new HashSet<> (),
+                    (set, accessor) -> {
+                        set.add(accessor.registryName());
+
+                        for (AssetAccessor<? extends StaticAnimation> subAnimAccessor : accessor.get().getSubAnimations()) {
+                            set.add(subAnimAccessor.registryName());
+                        }
+
+                        return set;
+                    },
+                    (set1, set2) -> {
+                        set1.addAll(set2);
+                        return set1;
+                    }
+                );
 		
-		/**
-		 * Load animations that are not registered by {@link AnimationRegistryEvent}
-		 * Reads from /assets folder in physical client, /datapack in physical server.
-		 */
-		objectIn.entrySet().stream().filter((entry) -> !registeredAnimation.contains(entry.getKey()) && !entry.getKey().getPath().contains("/data/") && !entry.getKey().getPath().contains("/pov/"))
-									.sorted((e1, e2) -> e1.getKey().toString().compareTo(e2.getKey().toString()))
-									.forEach((entry) -> {
-										try {
-											this.readResourcepackAnimation(entry.getKey(), entry.getValue().getAsJsonObject());
-										} catch (Exception e) {
-											EpicFightMod.LOGGER.error("Failed to load User animation " + entry.getKey() + " because of " + e + ". Skipped.");
-											e.printStackTrace();
-										}
-									});
-		
-		SkillManager.reloadAllSkillsAnimations();
-		
-		this.animations.entrySet().stream().reduce(Lists.<AssetAccessor<? extends StaticAnimation>>newArrayList(), (list, entry) -> {
-			MutableBoolean init = new MutableBoolean(true);
-			
-			if (entry.getValue() == null || entry.getValue().getAccessor() == null) {
-				EpicFightMod.logAndStacktraceIfDevSide(Logger::error, "Invalid animation implementation: " + entry.getKey(), AssetLoadingException::new);
-				init.set(false);
-			}
-			
-			entry.getValue().getSubAnimations().forEach((subAnimation) -> {
-				if (subAnimation == null || subAnimation.get() == null) {
-					EpicFightMod.logAndStacktraceIfDevSide(Logger::error, "Invalid sub animation implementation: " + entry.getKey(), AssetLoadingException::new);
-					init.set(false);
-				}
-			});
-			
-			if (init.value()) {
-				list.add(entry.getValue().getAccessor());
-				list.addAll(entry.getValue().getSubAnimations());
-			}
-			
-			return list;
-		}, (list1, list2) -> {
-			list1.addAll(list2);
-			return list1;
-		}).forEach((accessor) -> {
-			accessor.doOrThrow(StaticAnimation::postInit);
-			
-			if (EpicFightSharedConstants.isPhysicalClient()) {
-				AnimationManager.readAnimationProperties(accessor.get());
-			}
-		});
+		// Load animations that are not registered by AnimationRegistryEvent
+        // Reads from /assets folder in physical client, /datapack in physical server.
+        objects.stream()
+            .filter(animId -> !registeredAnimation.contains(animId) && !animId.getPath().contains("/data/") && !animId.getPath().contains("/pov/"))
+			.sorted(Comparator.comparing(ResourceLocation::toString))
+			.forEach(animId -> {
+                Optional<Resource> resource = resourceManager.getResource(idToPath(animId));
+                
+                try (Reader reader = resource.orElseThrow().openAsReader()) {
+                    JsonElement jsonelement = GsonHelper.fromJson(GSON, reader, JsonElement.class);
+                    this.readResourcepackAnimation(animId, jsonelement.getAsJsonObject());
+                } catch (IOException | JsonParseException | IllegalArgumentException resourceReadException) {
+                    EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId);
+                } catch (Exception e) {
+                    EpicFightMod.LOGGER.error("Failed at constructing {}", animId);
+                }
+            });
+        
+        SkillManager.reloadAllSkillsAnimations();
+        
+		this.animations.entrySet().stream()
+            .reduce(
+                new ArrayList<AssetAccessor<? extends StaticAnimation>>(),
+                (list, entry) -> {
+                    MutableBoolean init = new MutableBoolean(true);
+                    
+                    if (entry.getValue() == null || entry.getValue().getAccessor() == null) {
+                        EpicFightMod.logAndStacktraceIfDevSide(Logger::error, "Invalid animation implementation: " + entry.getKey(), AssetLoadingException::new);
+                        init.set(false);
+                    }
+                    
+                    entry.getValue().getSubAnimations().forEach((subAnimation) -> {
+                        if (subAnimation == null || subAnimation.get() == null) {
+                            EpicFightMod.logAndStacktraceIfDevSide(Logger::error, "Invalid sub animation implementation: " + entry.getKey(), AssetLoadingException::new);
+                            init.set(false);
+                        }
+                    });
+                    
+                    if (init.value()) {
+                        list.add(entry.getValue().getAccessor());
+                        list.addAll(entry.getValue().getSubAnimations());
+                    }
+                    
+                    return list;
+                },
+                (list1, list2) -> {
+                    list1.addAll(list2);
+                    return list1;
+                }
+            )
+            .forEach(accessor -> {
+                accessor.doOrThrow(StaticAnimation::postInit);
+
+                if (EpicFightSharedConstants.isPhysicalClient()) {
+                    AnimationManager.readAnimationProperties(accessor.get());
+                }
+            });
 	}
 	
 	public static ResourceLocation getSubAnimationFileLocation(ResourceLocation location, AnimationSubFileReader.SubFileType<?> subFileType) {
@@ -229,6 +256,16 @@ public class AnimationManager extends SimpleJsonResourceReloadListener {
 		
 		return ResourceLocation.fromNamespaceAndPath(location.getNamespace(), String.format("%s/" + subFileType.getDirectory() + "%s", location.getPath().substring(0, splitIdx), location.getPath().substring(splitIdx)));
 	}
+	
+	/// Converts animation id, acquired by [StaticAnimation#getRegistryName], to animation resource path acquired by [StaticAnimation#getLocation]
+    public static ResourceLocation idToPath(ResourceLocation rl) {
+        return rl.getPath().matches(DIRECTORY + "/.*\\.json") ? rl : ResourceLocation.fromNamespaceAndPath(rl.getNamespace(), DIRECTORY + rl.getPath() + ".json");
+    }
+
+    /// Converts animation resource path, acquired by [StaticAnimation#getLocation], to animation id acquired by [StaticAnimation#getRegistryName]
+    public static ResourceLocation pathToId(ResourceLocation rl) {
+        return ResourceLocation.fromNamespaceAndPath(rl.getNamespace(), rl.getPath().replace(DIRECTORY + "/", "").replace(".json", ""));
+    }
 	
 	public static void setServerResourceManager(ResourceManager pResourceManager) {
 		serverResourceManager = pResourceManager;

--- a/src/main/java/yesman/epicfight/api/animation/Animator.java
+++ b/src/main/java/yesman/epicfight/api/animation/Animator.java
@@ -109,7 +109,7 @@ public abstract class Animator {
 	}
 	
 	public void addLivingAnimation(LivingMotion livingMotion, AssetAccessor<? extends StaticAnimation> animation) {
-		if (!AnimationManager.checkNonNull(animation)) {
+		if (AnimationManager.checkNull(animation)) {
 			EpicFightMod.LOGGER.warn("Unable to put an empty animation for " + livingMotion);
 			return;
 		}

--- a/src/main/java/yesman/epicfight/api/client/animation/ClientAnimator.java
+++ b/src/main/java/yesman/epicfight/api/client/animation/ClientAnimator.java
@@ -137,7 +137,7 @@ public class ClientAnimator extends Animator {
 	
 	@Override
 	public void addLivingAnimation(LivingMotion livingMotion, AssetAccessor<? extends StaticAnimation> animation) {
-		if (!AnimationManager.checkNonNull(animation)) {
+		if (AnimationManager.checkNull(animation)) {
 			EpicFightMod.LOGGER.warn("Unable to put an empty animation for " + livingMotion);
 			return;
 		}

--- a/src/main/java/yesman/epicfight/main/EpicFightMod.java
+++ b/src/main/java/yesman/epicfight/main/EpicFightMod.java
@@ -1,13 +1,15 @@
 package yesman.epicfight.main;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import com.mojang.logging.LogUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+
+import com.mojang.logging.LogUtils;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -293,7 +295,7 @@ public class EpicFightMod {
     		AnimationManager.addNoWarningModId(EPICSKINS_MODID);
 			AnimationRegistryEvent animationregistryevent = new AnimationRegistryEvent();
     		ModLoader.get().postEvent(animationregistryevent);
-    		animationregistryevent.getBuilders().stream().sorted((b1, b2) -> b1.namespace().compareTo(b2.namespace())).forEach((builder) -> builder.task().accept(builder));
+    		animationregistryevent.getBuilders().stream().sorted(Comparator.comparing(AnimationManager.AnimationBuilder::namespace)).forEach((builder) -> builder.task().accept(builder));
     	});
     }
     

--- a/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
+++ b/src/main/java/yesman/epicfight/world/capabilities/item/WeaponCapability.java
@@ -251,7 +251,7 @@ public class WeaponCapability extends CapabilityItem {
 		}
 		
 		public Builder livingMotionModifier(Style wieldStyle, LivingMotion livingMotion, AnimationAccessor<? extends StaticAnimation> animation) {
-			if (!AnimationManager.checkNonNull(animation)) {
+			if (AnimationManager.checkNull(animation)) {
 				EpicFightMod.LOGGER.warn("Unable to put an empty animation to weapon capability builder: " + livingMotion + ", " + animation);
 				return this;
 			}


### PR DESCRIPTION
Initially reported by [P1nero](https://github.com/GaylordFockerCN), the author of the Casket of Reveries and Sword Soaring. 
He reported the memory usage had greatly increased while loading the game with addons that have large animation files. I figured out it was because `AnimationManager` creates json elements for each animation instance. 

```java
protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profilerIn) {
	if (!EpicFightSharedConstants.isPhysicalClient() && serverResourceManager == null) {
		serverResourceManager = resourceManager;
	}
	
	this.animations.clear();
	this.animationById.entrySet().removeIf((entry) -> !entry.getValue().inRegistry());
	this.animationByName.entrySet().removeIf((entry) -> !entry.getValue().inRegistry());
	this.resourcepackAnimationCommands.clear();
	
	return super.prepare(resourceManager, profilerIn); // Where the `JsonElements` are created
}
```

<img width="2284" height="1404" alt="image" src="https://github.com/user-attachments/assets/2b437d8e-ead6-45db-929f-d20d1a0a8ddb" />

_He also attached the issue with the memory examination tool. Json instance is occupying a lot of memory space._

The solution is refactoring `AnimationManager` to `SimplePreparableReloadListener`, which you can use `List` instead of `Map` so we can extract only the file names of resources under `animmodels/animation/` directory.

```java
protected List<ResourceLocation> prepare(ResourceManager resourceManager, ProfilerFiller profilerIn) {
	if (!EpicFightSharedConstants.isPhysicalClient() && serverResourceManager == null) {
		serverResourceManager = resourceManager;
	}
	
	this.animations.clear();
	this.animationById.entrySet().removeIf(entry -> !entry.getValue().inRegistry());
	this.animationByName.entrySet().removeIf(entry -> !entry.getValue().inRegistry());
	this.resourcepackAnimationCommands.clear();
	
   List<ResourceLocation> directories = new ArrayList<> ();
   scanDirectoryNames(resourceManager, directories);
       
	return directories;
}

private static void scanDirectoryNames(ResourceManager resourceManager, List<ResourceLocation> output) {
    FileToIdConverter filetoidconverter = FileToIdConverter.json(DIRECTORY);
    // In this code, it extract animation ids through the listed resourced by `listMatchingResources` method
    filetoidconverter.listMatchingResources(resourceManager).keySet().stream().map(AnimationManager::pathToId).forEach(output::add);
}
```
Then we can extract the json file for user-defined animations
```java
objects.stream()
    .filter(animId -> !registeredAnimation.contains(animId) && !animId.getPath().contains("/data/") && !animId.getPath().contains("/pov/"))
	.sorted(Comparator.comparing(ResourceLocation::toString))
    .forEach(animId -> {
        Optional<Resource> resource = resourceManager.getResource(idToPath(animId));
        // read json file by animation id
        try (Reader reader = resource.orElseThrow().openAsReader()) {
            JsonElement jsonelement = GsonHelper.fromJson(GSON, reader, JsonElement.class);
            this.readResourcepackAnimation(animId, jsonelement.getAsJsonObject());
        } catch (IOException | JsonParseException | IllegalArgumentException resourceReadException) {
            EpicFightMod.LOGGER.error("Couldn't parse animation data from {}", animId);
        } catch (Exception e) {
            EpicFightMod.LOGGER.error("Failed at constructing {}", animId);
        }
    });
```